### PR TITLE
chore: Fix typo in dspico-pcb/README.md

### DIFF
--- a/dspico-pcb/README.md
+++ b/dspico-pcb/README.md
@@ -108,7 +108,7 @@ If they contact you via email after placing the order about this note, attach th
    - Bake Components: **No**
    - Board Cleaning: **Yes**
    - Packaging: **Antistatic bubble film**.
-   - Solder Paste: **SN96.5%, Ag3.0%, Cu0.5%(260ºC)**
+   - Solder Paste: **High Temp.**
    - Add paste for unpopulated pad & step stencil opening: **No**
    - Function test: **No** 
    - Photo confirmation: **No**


### PR DESCRIPTION
While following the guide I found a very tiny typo so I fix it